### PR TITLE
Add simple support for per language translations

### DIFF
--- a/source/translator.d
+++ b/source/translator.d
@@ -1,0 +1,35 @@
+private string[string] defaultLanguage;
+static this()
+{
+	defaultLanguage = [
+		"editor.run": "Run",
+		"editor.reset": "Reset",
+		"editor.format": "Format",
+		"editor.keyboard_shortcuts": "Keyboard Shortcuts",
+	];
+}
+
+/**
+Allows per-language overwrites of UI text
+*/
+class Translator
+{
+	string[string] translations;
+
+	// in case no translation is found
+	this() {}
+
+	this(string[string] translations)
+	{
+		this.translations = translations;
+	}
+
+	// uses default language as fallback
+	string opIndex(string key) const
+	{
+		if (auto value = key in translations)
+			return *value;
+
+		return defaultLanguage[key];
+	}
+}

--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -157,11 +157,13 @@ class WebInterface
 		auto nextSection = sec.linkCache.nextSection;
 		auto googleAnalyticsId = googleAnalyticsId_;
 		auto title = sec.tourData.content.title ~ " - " ~ contentProvider_.getMeta(_language).title;
-		auto githubRepo = contentProvider_.getMeta(_language).repo;
+		auto meta = contentProvider_.getMeta(_language);
+		auto githubRepo = meta.repo;
+		auto translations = meta.translator;
 		render!("tour.dt", htmlContent, language, section, sectionId,
 				sectionCount, chapterId, hasSourceCode, sourceCodeEnabled,
 				nextSection, previousSection, googleAnalyticsId,
-				toc, title, githubRepo)();
+				toc, title, githubRepo, translations)();
 	}
 
 	@path("/editor")

--- a/views/tour.dt
+++ b/views/tour.dt
@@ -35,13 +35,13 @@ block content
 				- if (sourceCodeEnabled)
 					button.btn.btn-primary(ng-click="run()")
 						i.fa.fa-play(aria-hidden="true")
-						span Run
+						span #{translations["editor.run"]}
 					button.btn.btn-primary(ng-click="format()")
 						i.fa.fa-play(aria-hidden="true")
-						span Format
+						span #{translations["editor.format"]}
 					button.btn.btn-default(ng-click="reset()")
 						i.fa.fa-undo(aria-hidden="true")
-						span Reset
+						span #{translations["editor.reset"]}
 					button.btn.btn-default(ng-click="export()")
 						i.fa.fa-share(aria-hidden="true")
 						span Export
@@ -60,7 +60,7 @@ block content
 		.container.hidden-xs.hidden-sm
 			p.text-muted.text-center
 				kbd ?
-				| Keyboard shortcuts
+				| #{translations["editor.keyboard_shortcuts"]}
 
 block js
 	script(src="/static/js/tour-controller.js")


### PR DESCRIPTION
As [promised](https://github.com/stonemaster/dlang-tour/issues/506#issuecomment-302729641) here's the PR to support translations for the language repository.
It's really simple: we define a default dictionary with keys which we use as fallback and lookup the `translations` dictionary in the `index.yml`.
This means once this is merged, we can (1) start extending this for more keys and (2) ping all language maintainer to use start adding language translation to their `index.yml`