### PR TITLE
Add simple editor with export option (e.g. for "open in editor")

### DIFF
--- a/public/static/js/menu.js
+++ b/public/static/js/menu.js
@@ -1,3 +1,4 @@
+(function initMenu() {
 if (typeof cssmenu_no_js === 'undefined') {
     var open_main_item = null;
 
@@ -19,6 +20,9 @@ if (typeof cssmenu_no_js === 'undefined') {
 
     // menu button for mobile devices
     var dom_hamburger = document.body.querySelector(".hamburger.expand-toggle");
+	if (!dom_hamburger) {
+		return;
+	}
     dom_hamburger.addEventListener('click', function(e){
         handleMenuClick(dom_hamburger.parentNode, e, true);
     });
@@ -42,3 +46,4 @@ if (typeof cssmenu_no_js === 'undefined') {
         open_main_item = null;
     });
 }
+})();

--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -1,5 +1,12 @@
 var dlangTourApp = angular.module('DlangTourApp', ['ui.codemirror', 'cfp.hotkeys']);
 
+function b64DecodeUnicode(str) {
+    // Going backwards: from bytestream, to percent-encoding, to original string.
+    return decodeURIComponent(atob(str).split('').map(function(c) {
+        return '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2);
+    }).join(''));
+}
+
 dlangTourApp.controller('DlangTourAppCtrl',
 	['$scope', '$http', 'hotkeys', '$window',
 	function($scope, $http, hotkeys, $window) {
@@ -71,7 +78,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 		}
 	};
 
-	$scope.init = function(language, githubRepo, chapterId, section, hasSourceCode, prevPage, nextPage) {
+	$scope.initTour = function(language, githubRepo, chapterId, section, hasSourceCode, prevPage, nextPage) {
 		$scope.language = language;
 		$scope.githubRepo = githubRepo;
 		$scope.chapterId = chapterId;
@@ -92,6 +99,11 @@ dlangTourApp.controller('DlangTourAppCtrl',
 		});
 
 		$scope.showSourceCode = hasSourceCode;
+	}
+
+	$scope.initEditor = function(sourceCode) {
+		$scope.resetCode = b64DecodeUnicode(sourceCode);
+		$scope.sourceCode = $scope.resetCode;
 	}
 
 	$scope.run = function() {
@@ -121,6 +133,10 @@ dlangTourApp.controller('DlangTourAppCtrl',
 
 	$scope.reset = function() {
 		$scope.sourceCode = $scope.resetCode;
+	}
+
+	$scope.export = function() {
+		window.location = window.location.origin + "/editor?source=" + encodeURIComponent($scope.sourceCode);
 	}
 
 	$scope.format = function() {

--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -163,4 +163,25 @@ class WebInterface
 				nextSection, previousSection, googleAnalyticsId,
 				toc, title, githubRepo)();
 	}
+
+	@path("/editor")
+	void getEditor(HTTPServerRequest req, HTTPServerResponse res)
+	{
+		import std.base64;
+		auto googleAnalyticsId = googleAnalyticsId_;
+		auto title = "Editor";
+		bool toc;
+		auto chapterId = "";
+		auto language = "en";
+		string sourceCode;
+		if (auto s = "source" in req.query) {
+			sourceCode = Base64.encode(cast(ubyte[]) *s);
+		} else if (auto s = "b64source" in req.query) {
+			sourceCode = *s;
+		} else {
+			auto sourceCodeRaw = "import std.stdio;\nvoid main(string[] args)\n{\n    writeln(\"Hello D\");\n}";
+			sourceCode = Base64.encode(cast(ubyte[]) sourceCodeRaw);
+		}
+		render!("editor.dt", googleAnalyticsId, title, toc, chapterId, language, sourceCode)();
+	}
 }

--- a/views/base.dt
+++ b/views/base.dt
@@ -13,32 +13,33 @@ head
 	script(src="https://ajax.googleapis.com/ajax/libs/angularjs/1.4.9/angular.min.js")
 
 body(ng-app="DlangTourApp", class="ng-cloak")
-	#top
-		.helper
-			.helper.expand-container.active
-				.logo
-					a(href="https://dlang.org")
-						img(id="logo", alt="DLang Logo", src="/static/img/dlogo.svg")
-					a(href="#{req.rootDir}", id="title")
-						span The DLang Tour
-				a(href="#", title="Menu", class="hamburger expand-toggle")
-					span Menu
-				#cssmenu
-					ul
-						- foreach(ref tocItem; toc)
-							- auto active = chapterId == tocItem.chapterId;
-							li(class=(active ? "expand-container active" : "expand-container"))
-								a.expand-toggle(href="#")
-									span=tocItem.title
-								ul.expand-content
-									- foreach(ref sec; tocItem.sections)
-										li(class=(active ? "active" : ""))
-											a(href="/tour/#{language}/#{tocItem.chapterId}/#{sec.sectionId}")
-												span=sec.title
+	- static if (!(is(typeof(toc) == bool)))
+		#top
+			.helper
+				.helper.expand-container.active
+					.logo
+						a(href="https://dlang.org")
+							img(id="logo", alt="DLang Logo", src="/static/img/dlogo.svg")
+						a(href="#{req.rootDir}", id="title")
+							span The DLang Tour
+					a(href="#", title="Menu", class="hamburger expand-toggle")
+						span Menu
+					#cssmenu
+						ul
+							- foreach(ref tocItem; toc)
+								- auto active = chapterId == tocItem.chapterId;
+								li(class=(active ? "expand-container active" : "expand-container"))
+									a.expand-toggle(href="#")
+										span=tocItem.title
+									ul.expand-content
+										- foreach(ref sec; tocItem.sections)
+											li(class=(active ? "active" : ""))
+												a(href="/tour/#{language}/#{tocItem.chapterId}/#{sec.sectionId}")
+													span=sec.title
 
-				#github_avatar
-					a(href="https://github.com/stonemaster/dlang-tour")
-						i(class="fa fa-github",aria-hidden="true")
+					#github_avatar
+						a(href="https://github.com/stonemaster/dlang-tour")
+							i(class="fa fa-github",aria-hidden="true")
 
 	block content
 

--- a/views/editor.dt
+++ b/views/editor.dt
@@ -1,0 +1,39 @@
+extends base
+
+block head
+	link(rel="stylesheet", href="/static/lib/hotkeys.min.css")
+	link(rel="stylesheet", href="/static/lib/codemirror/lib/codemirror.min.css")
+	link(rel="stylesheet", href="/static/lib/codemirror/addon/lint/lint.min.css")
+	link(rel="stylesheet", href="/static/lib/codemirror/theme/elegant.css")
+	link(rel="stylesheet", href="/static/lib/grid12.min.css")
+
+block content
+	.row(ng-controller="DlangTourAppCtrl as ctrl", ng-init="initEditor('#{sourceCode}')")
+		div#tour-content(ng-show="showProgramOutput", ng-class="{'col-md-12': !showSourceCode, 'col-md-6 col-sm-12': showSourceCode}")
+			.content-command-box
+				button.btn.btn-danger.btn-sm(ng-click="showProgramOutput = !showProgramOutput")
+					span.fa.fa-close
+			h2.program-output-title rdmd playground.d
+			pre#program-output {{programOutput}}
+		div(ng-class="{'col-md-6 col-sm-12': showContent, 'col-md-12': !showContent}", style="padding-left: 0px; padding-right: 0px")
+			div#command-box.text-right
+				button.btn.btn-primary(ng-click="run()")
+					i.fa.fa-play(aria-hidden="true")
+					span Run
+				button.btn.btn-default(ng-click="reset()")
+					i.fa.fa-undo(aria-hidden="true")
+					span Reset
+				button.btn.btn-default(ng-click="export()")
+					i.fa.fa-share(aria-hidden="true")
+					span Export
+			ui-codemirror(ui-codemirror-opts="editorOptions", ui-codemirror="{ onLoad : codemirrorLoaded }", ng-model="sourceCode")
+
+block js
+	script(src="/static/js/tour-controller.js")
+	script(src="/static/js/swipe.js")
+	script(src="/static/lib/codemirror/lib/codemirror.min.js")
+	script(src="/static/lib/codemirror/mode/d/d.min.js")
+	script(src="/static/lib/codemirror/addon/lint/lint.min.js")
+	script(src="/static/lib/codemirror/addon/runmode.js")
+	script(src="/static/lib/ui-codemirror.min.js")
+	script(src="/static/lib/hotkeys.min.js")

--- a/views/tour.dt
+++ b/views/tour.dt
@@ -8,7 +8,7 @@ block head
 	link(rel="stylesheet", href="/static/lib/grid12.min.css")
 
 block content
-	.row(ng-controller="DlangTourAppCtrl as ctrl", ng-init="init('#{language}', '#{githubRepo}', '#{chapterId}', '#{section}', #{hasSourceCode}, '#{previousSection.link}', '#{nextSection.link}')")
+	.row(ng-controller="DlangTourAppCtrl as ctrl", ng-init="initTour('#{language}', '#{githubRepo}', '#{chapterId}', '#{section}', #{hasSourceCode}, '#{previousSection.link}', '#{nextSection.link}')")
 		div#tour-content(ng-show="showContent", ng-class="{'col-md-12': !showSourceCode, 'col-md-7 col-sm-12': showSourceCode}")
 			div(ng-hide="showProgramOutput")
 				.content-command-box
@@ -42,6 +42,9 @@ block content
 					button.btn.btn-default(ng-click="reset()")
 						i.fa.fa-undo(aria-hidden="true")
 						span Reset
+					button.btn.btn-default(ng-click="export()")
+						i.fa.fa-share(aria-hidden="true")
+						span Export
 			ui-codemirror(ui-codemirror-opts="editorOptions", ui-codemirror="{ onLoad : codemirrorLoaded }", ng-model="sourceCode")
 
 	nav.navbar.navbar-bottom


### PR DESCRIPTION
This is a simple way to use the Dlang Tour as a DPaste-esque editor.
It is intended to be used for the examples on dlang.org, s.t. we can have a nice button "Open in editor" there.

This is a minimal working PR (I tried to keep the changeset minimal).
Of course, we can add more complicated features to the editor once merged (e.g. using the localStorage for caching). Also I realized that there is some weirdness with the toc going on (we pass a reference of a class into the Diet templates and dereference shortly afterwards, but I kept this refatoring out of this PR).

### /editor

![image](https://cloud.githubusercontent.com/assets/4370550/26755707/8a9e10de-4893-11e7-8f6c-23dc45602df2.png)

After execution:

![image](https://cloud.githubusercontent.com/assets/4370550/26755735/4b2e6a1a-4894-11e7-9772-0be68dbdd033.png)
