### PR TITLE
Add a stupidly simple DUB exec provider

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -8,7 +8,8 @@ import config;
 import rest.apiv1;
 
 import exec.cache;
-import exec.stupidlocal;
+import exec.stupidlocaldmd;
+import exec.stupidlocaldub;
 import exec.iexecprovider;
 import exec.off;
 import exec.docker;
@@ -25,7 +26,11 @@ private IExecProvider createExecProvider(Config config,
 
 	switch (config.execProvider) {
 		case "stupidlocal":
-			execProvider = new StupidLocal;
+		case "stupidlocaldmd":
+			execProvider = new StupidLocalDmd;
+			break;
+		case "stupidlocaldub":
+			execProvider = new StupidLocalDub;
 			break;
 		case "off":
 			return new Off;

--- a/source/exec/stupidlocaldmd.d
+++ b/source/exec/stupidlocaldmd.d
@@ -1,4 +1,4 @@
-module exec.stupidlocal;
+module exec.stupidlocaldmd;
 
 import exec.iexecprovider;
 
@@ -37,7 +37,7 @@ private string findDCompiler()
 	Warning:
 		UNSAFE BECUASE CODE IS RUN UNFILTERED AND NOT IN A SANDBOX
 +/
-class StupidLocal: IExecProvider
+class StupidLocalDmd : IExecProvider
 {
 	string dCompiler = "dmd";
 	this() {

--- a/source/exec/stupidlocaldub.d
+++ b/source/exec/stupidlocaldub.d
@@ -1,0 +1,67 @@
+module exec.stupidlocaldub;
+
+import exec.iexecprovider;
+
+import vibe.core.core: sleep, runTask;
+import core.time : msecs;
+
+import std.process;
+import std.typecons: Tuple;
+import std.file: exists, remove, tempDir;
+import std.stdio: File;
+import std.random: uniform;
+import std.string: format;
+
+/++
+	Stupid local executor which just runs dub and passes the source to it
+	and outputs the executes binary's output.
+
+	Warning:
+		UNSAFE BECUASE CODE IS RUN UNFILTERED AND NOT IN A SANDBOX
++/
+class StupidLocalDub : IExecProvider
+{
+	private File getTempFile()
+	{
+		auto tempdir = tempDir();
+
+		static string randomName()
+		{
+			enum Length = 10;
+			char[Length] res;
+			foreach (ref c; res) {
+				c = cast(char)('a' + uniform(0, 'z'-'a'));
+			}
+			return res.idup;
+		}
+
+		string tempname;
+		do {
+			tempname = "%s/temp_dlang_tour_%s.d".format(tempdir, randomName());
+		} while (exists(tempname));
+
+		File tempfile;
+		tempfile.open(tempname, "wb");
+		return tempfile;
+	}
+
+	Tuple!(string, "output", bool, "success") compileAndExecute(string source)
+	{
+		typeof(return) result;
+		auto task = runTask(() {
+			auto tmpfile = getTempFile();
+			scope(exit) tmpfile.name.remove;
+
+			tmpfile.write(source);
+			tmpfile.close();
+			auto rdmd = execute(["dub", "run", "--single", tmpfile.name]);
+			result.success = rdmd.status == 0;
+			result.output = rdmd.output;
+		});
+
+		while (task.running)
+			sleep(10.msecs);
+
+		return result;
+	}
+}


### PR DESCRIPTION
Hey,

this is a first attempt to add DUB to the dlang-tour.
It's intended to have a usable DUB exec provide to play with and figure out the remaining problems of https://github.com/dlang-tour/dlang-tour/issues/27

- [ ] Adding `dlang-tour-dub` Docker container
- [ ] Mount an external DUB cache to `dlang-tour-dub`, which should get emptied from time to time by a cron (optional: add a maximal limit to the disk drive)
- [ ] Figure out how we want to pass DUB dependencies to the execution thread (I guess using the `dub.(sdl|json)` is the best because it will "just work" when users want to continue on their local machine.). We could detect the DUB header in the API and then call a new `compileAndExecuteWithDependencies(string source)` method. Btw, with https://github.com/dlang/dub/pull/1081 merged, the DUB header could look quite.

For references, the current API is pretty simple:

```
interface IExecProvider
{
	Tuple!(string, "output", bool, "success") compileAndExecute(string source);
}
```

### An example from `mir`:

This already works nicely work `stupidlocaldub`:

```d
/+ dub.sdl:
name "foo"
dependency "mir-algorithm" version="~master"
+/

void main() {
    import mir.ndslice.topology : iota;
    import mir.ndslice.algorithm : reduce;
    import std.stdio : writeln;

    //| 0 1 2 | => 3  |
    //| 3 4 5 | => 12 | => 15
    auto sl = iota(2, 3);

    // sum of all element in the slice
    size_t(0).reduce!"a + b"(sl).writeln;
}
```