### PR TITLE
Always use port 443 for SSL redirects

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -175,6 +175,7 @@ shared static this()
 		listenHTTP(settings, (req, res) {
 			auto url = req.fullURL;
 			url.schema = "https";
+			url.port = 443;
 			res.redirect(url);
 		});
 		listenHTTP(httpsSettings, urlRouter);


### PR DESCRIPTION
Currently when one opens the tour, it redirects to https://tour.dlang.org:8080

Will merge this immediately, as it's a hotfix.


https://github.com/dlang-tour/spanish/issues/9