### PR TITLE
Fix JavaScript errors on run

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -117,7 +117,8 @@ dlangTourApp.controller('DlangTourAppCtrl',
 
 		$http.post('/api/v1/run', {
 			source: $scope.sourceCode
-		}).then(function(data) {
+		}).then(function(body) {
+			var data = body.data;
 			$scope.programOutput = data.output;
 			$scope.warnings = data.warnings;
 			$scope.errors = data.errors;


### PR DESCRIPTION
Seems like Angular uses a different format between `.success` and `.then` - argh ...
Follow-up to https://github.com/dlang-tour/core/pull/536