### PR TITLE
Cache user code snippets as well

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -44,10 +44,7 @@ private IExecProvider createExecProvider(Config config,
 
 	if (config.enableExecCache) {
 		import std.algorithm: map;
-		auto allowedSources = contentProvider.getContent()
-			.map!(x => x.sourceCode.idup)
-			.array;
-		return new Cache(execProvider, allowedSources);
+		return new Cache(execProvider, 50_000);
 	}
 	return execProvider;
 }


### PR DESCRIPTION
This is important when we start receiving requests from dlang.org.

![image](https://user-images.githubusercontent.com/4370550/27634134-67a5a1f0-5c02-11e7-9446-5606631155b2.png)

The second request pair is with caching. Of course, without starting docker the execution is faster which btw we might be interested in looking into Linux LXC containers (see also: https://unix.stackexchange.com/questions/254956/what-is-the-difference-between-docker-lxd-and-lxc).

There is an outstanding issue with CORS for dlang.org, hence two requests are sent, but this is part of another PR.