### PR TITLE
Fix release compiler to ldc-1.2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ d:
   - dmd-nightly
   - ldc
   - ldc-beta
+  # used to build the release application
+  - ldc-1.2.0
 
 cache:
   - $HOME/.dub
@@ -38,6 +40,6 @@ script:
   - if [[ "${DC}" == "ldc2" ]]; then docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti stonemaster/dlang-tour --sanitycheck ; fi
 
 after_success:
-  - if [[ "${DC}" == "ldc2" && "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi
-  - if [[ "${DC}" == "ldc2" && "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then docker push stonemaster/dlang-tour       ; fi
+  - if [[ "${DC}" == "ldc2" && "$(ldc --version | head -n1 | sed -E 's/.*\((.*)\).*/\1/')" == "1.2.0" && "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi
+  - if [[ "${DC}" == "ldc2" && && "$(ldc --version | head -n1 | sed -E 's/.*\((.*)\).*/\1/')" == "1.2.0" && "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then docker push stonemaster/dlang-tour       ; fi
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
- First LDC 1.3.0 beta has been [released](https://github.com/ldc-developers/ldc/releases) in May 2017
- My best bet is that our random build failures are due to ldc 1.2.0 (working) and ldc-1.3.0-beta (failing) pushing Docker images more or less simultaneously
- In any case, fixing the release compiler is definitely a good thing (even if it just helps to rule out this as cause)
- This won't be run on the Travis PR run - we explicitly avoid this of course ;-)