### PR TITLE
Fix #562 - support run.dlang.io as standalone instance for the editor

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -138,7 +138,12 @@ dlangTourApp.controller('DlangTourAppCtrl',
 	}
 
 	$scope.export = function() {
-		window.location = window.location.origin + "/editor?source=" + encodeURIComponent($scope.sourceCode);
+		var encodedSource = encodeURIComponent($scope.sourceCode);
+		// A local user might be offline, so we don't want to redirect him to the online editor
+		if (location.hostname === "localhost" || location.hostname === "127.0.0.1" || location.hostname === "0.0.0.0")
+			window.location = window.location.origin + "/editor?source=" + encodedSource;
+		else
+			window.location = "https://run.dlang.io?source=" + encodedSource;
 	}
 
 	// boostrap copy-to-clipboard buttons (only necessary once)

--- a/source/app.d
+++ b/source/app.d
@@ -169,7 +169,8 @@ shared static this()
 	void cors(HTTPServerRequest req, HTTPServerResponse res)
 	{
 		import std.algorithm: among, equal, until;
-		if (req.host.until(":").among!equal("tour.dlang.org", "tour.dlang.io", "dlang.org", "dtest.dlang.io", "127.0.0.1", "localhost"))
+		if (req.host.until(":").among!equal("tour.dlang.org", "tour.dlang.io", "run.dlang.io",
+					"dlang.org", "dtest.dlang.io", "127.0.0.1", "localhost"))
 		{
 			res.headers["Access-Control-Allow-Origin"] = "*";
 		}

--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -108,7 +108,11 @@ class WebInterface
 
 	void index(HTTPServerRequest req, HTTPServerResponse res)
 	{
-		getStart(req, res, defaultLang);
+		// support "standalone" mode of the editor
+		if (req.host == "run.dlang.io")
+			getEditor(req, res);
+		else
+			getStart(req, res, defaultLang);
 	}
 
 	@path("/tour/:language")


### PR DESCRIPTION
As the vibe.d instance handles all requests (there seems to be no nginx/apache or other reverse proxy in-between), this is the easiest way to add `run.dlang.io`

Note that I initially added https://editor.dlang.io, but then decided to go with `run.dlang.io` because maybe at some point in the distant future some creates a fancy D editor ;-)

For some reasons letsencrypt does like `run.dlang.io` yet, but I can probably add the certificate soon (this doesn't block this PR as no one browses run.dlang.io yet).
I don't know yet how @stonemaster has setup auto-updating letsencrypt, but I will send a ping soon (again, this doesn't block this PR as its a simple question).