### PR TITLE
Fix title to DLang-Tour

### DIFF
--- a/views/base.dt
+++ b/views/base.dt
@@ -21,7 +21,7 @@ body(ng-app="DlangTourApp", class="ng-cloak")
 						a(href="https://dlang.org")
 							img(id="logo", alt="DLang Logo", src="/static/img/dlogo.svg")
 						a(href="#{req.rootDir}", id="title")
-							span #{title}
+							span DLang-Tour
 					a(href="#", title="Menu", class="hamburger expand-toggle")
 						span Menu
 					#cssmenu


### PR DESCRIPTION
Currently we don't require a translation instance for the `base` layout (it's also used by the error messages and the editor).

So I guess the simplest solution is to revert #566 partially and just use "DLang-Tour" as universal title.

See also: https://github.com/dlang-tour/german/pull/61