### PR TITLE
Fix issue #569 - Add space between fa icons and text in the editor buttons

### DIFF
--- a/public/static/css/common.css
+++ b/public/static/css/common.css
@@ -103,6 +103,10 @@ body {
     border-color: #adadad;
 }
 
+button > i + span {
+	margin-left: 5px;
+}
+
 button, input, optgroup, select {
     font: inherit;
 }


### PR DESCRIPTION
For comparison:

* before: 
![before](https://user-images.githubusercontent.com/3475150/27926410-099878c2-6291-11e7-8736-0a2965f34494.png)

* after: 
![after](https://user-images.githubusercontent.com/3475150/27926425-0fb61b10-6291-11e7-8ee8-a60d3712b31f.png)

