### PR TITLE
[WIP] Support choosing D compiler in the playground

### DIFF
--- a/source/exec/cache.d
+++ b/source/exec/cache.d
@@ -38,19 +38,19 @@ class Cache: IExecProvider
 		assert(sourceCodeWhitelist.length == this.allowedSources_.length);
 	}
 
-	Tuple!(string, "output", bool, "success") compileAndExecute(string source)
+	Tuple!(string, "output", bool, "success") compileAndExecute(string source, string compiler = "dmd")
 	{
 		import std.range: assumeSorted;
 		import std.algorithm: canFind;
 		auto hash = getSourceCodeHash(source);
 
 		if (!assumeSorted(this.allowedSources_).canFind(hash)) {
-			auto result = realExecProvider_.compileAndExecute(source);
+			auto result = realExecProvider_.compileAndExecute(source, compiler);
 			return result;
 		} else if (auto cache = hash in sourceHashToOutput_) {
 			return *cache;
 		} else {
-			auto result = realExecProvider_.compileAndExecute(source);
+			auto result = realExecProvider_.compileAndExecute(source, compiler);
 			sourceHashToOutput_[hash] = result;
 			return result;
 		}

--- a/source/exec/docker.d
+++ b/source/exec/docker.d
@@ -18,7 +18,15 @@ import std.conv: to;
 +/
 class Docker: IExecProvider
 {
-	private immutable DockerImage = "stonemaster/dlang-tour-rdmd";
+	private immutable BaseDockerImage = "dlangtour/core-exec";
+	private immutable DockerImages = [
+		BaseDockerImage ~ ":dmd",
+		BaseDockerImage ~ ":dmd-beta",
+		BaseDockerImage ~ ":dmd-nightly",
+		BaseDockerImage ~ ":ldc",
+		BaseDockerImage ~ ":ldc-beta",
+		BaseDockerImage ~ ":gdc"
+	];
 
 	private int timeLimitInSeconds_;
 	private int maximumOutputSize_;
@@ -44,31 +52,37 @@ class Docker: IExecProvider
 		logInfo("Maximum Queue Size: %d", maximumQueueSize_);
 		logInfo("Memory Limit: %d MB", memoryLimitMB_);
 		logInfo("Output size limit: %d B", maximumQueueSize_);
-		logInfo("Checking whether Docker is functional and updating Docker image '%s'", DockerImage);
-		logInfo("Using docker binary at '%s'", dockerBinaryPath);
 
-		auto docker = execute([this.dockerBinaryPath_, "ps"]);
-		if (docker.status != 0) {
-			throw new Exception("Docker doesn't seem to be functional. Error: '"
-					~ docker.output ~ "'. RC: " ~ to!string(docker.status));
+		foreach (dockerImage; DockerImages)
+		{
+
+			logInfo("Checking whether Docker is functional and updating Docker image '%s'", dockerImage);
+			logInfo("Using docker binary at '%s'", dockerBinaryPath);
+
+			auto docker = execute([this.dockerBinaryPath_, "ps"]);
+			if (docker.status != 0) {
+				throw new Exception("Docker doesn't seem to be functional. Error: '"
+						~ docker.output ~ "'. RC: " ~ to!string(docker.status));
+			}
+
+			auto dockerPull = execute([this.dockerBinaryPath_, "pull", dockerImage]);
+			if (docker.status != 0) {
+				throw new Exception("Failed pulling RDMD Docker image. Error: '" ~ docker.output
+						~ "'. RC: " ~ to!string(docker.status));
+			}
+
+			logInfo("Pulled Docker image '%s'.", dockerImage);
+			logInfo("Verifying functionality with 'Hello World' program...");
+			auto result = compileAndExecute(q{void main() { import std.stdio; write("Hello World"); }});
+			enforce(result.success && result.output == "Hello World",
+					new Exception("Compiling 'Hello World' wasn't successful: " ~ result.output));
 		}
-
-		auto dockerPull = execute([this.dockerBinaryPath_, "pull", DockerImage]);
-		if (docker.status != 0) {
-			throw new Exception("Failed pulling RDMD Docker image. Error: '" ~ docker.output
-					~ "'. RC: " ~ to!string(docker.status));
-		}
-
-		logInfo("Pulled Docker image '%s'.", DockerImage);
-		logInfo("Verifying functionality with 'Hello World' program...");
-		auto result = compileAndExecute(q{void main() { import std.stdio; write("Hello World"); }});
-		enforce(result.success && result.output == "Hello World",
-				new Exception("Compiling 'Hello World' wasn't successful: " ~ result.output));
 	}
 
-	Tuple!(string, "output", bool, "success") compileAndExecute(string source)
+	Tuple!(string, "output", bool, "success") compileAndExecute(string source, string compiler = "dmd")
 	{
 		import std.string: format;
+		import std.algorithm.searching : canFind, find;
 
 		if (queueSize_ > maximumQueueSize_) {
 			return typeof(return)("Maximum number of parallel compiles has been exceeded. Try again later.", false);
@@ -79,10 +93,15 @@ class Docker: IExecProvider
 			--queueSize_;
 
 		auto encoded = Base64.encode(cast(ubyte[])source);
+		// try to find the compiler in the available images
+		auto r = DockerImages.find!(d => d.canFind(compiler));
+		// use dmd as fallback
+		const dockerImage = (r.length > 0) ? r[0] : DockerImages[0];
+
 		auto docker = pipeProcess([this.dockerBinaryPath_, "run", "--rm",
 				"--net=none", "--memory-swap=-1",
 				"-m", to!string(memoryLimitMB_ * 1024 * 1024),
-				DockerImage, encoded],
+				dockerImage, encoded],
 				Redirect.stdout | Redirect.stderrToStdout | Redirect.stdin);
 		docker.stdin.write(encoded);
 		docker.stdin.flush();

--- a/source/exec/iexecprovider.d
+++ b/source/exec/iexecprovider.d
@@ -8,5 +8,5 @@ import std.typecons: Tuple;
 +/
 interface IExecProvider
 {
-	Tuple!(string, "output", bool, "success") compileAndExecute(string source);
+	Tuple!(string, "output", bool, "success") compileAndExecute(string source, string compiler = "dmd");
 }

--- a/source/exec/off.d
+++ b/source/exec/off.d
@@ -6,7 +6,7 @@ import std.typecons: Tuple;
 
 class Off: IExecProvider
 {
-	Tuple!(string, "output", bool, "success") compileAndExecute(string source)
+	Tuple!(string, "output", bool, "success") compileAndExecute(string source, string compiler = "dmd")
 	{
 		return typeof(return)("Service currently unavailable", false);
 	}

--- a/source/exec/stupidlocal.d
+++ b/source/exec/stupidlocal.d
@@ -69,7 +69,7 @@ class StupidLocal: IExecProvider
 		return tempfile;
 	}
 
-	Tuple!(string, "output", bool, "success") compileAndExecute(string source)
+	Tuple!(string, "output", bool, "success") compileAndExecute(string source, string compiler = "dmd")
 	{
 		typeof(return) result;
 		auto task = runTask(() {

--- a/source/rest/apiv1.d
+++ b/source/rest/apiv1.d
@@ -53,13 +53,13 @@ class ApiV1: IApiV1
 		}
 	}
 
-	RunOutput run(string source)
+	RunOutput run(string source, string compiler)
 	{
 		if (source.length > 4 * 1024) {
 			return RunOutput("ERROR: source code size is above limit.", false);
 		}
 
-		auto result = execProvider_.compileAndExecute(source);
+		auto result = execProvider_.compileAndExecute(source, compiler);
 		auto output = RunOutput(result.output, result.success);
 		parseErrorsAndWarnings(output);
 		return output;

--- a/source/rest/iapiv1.d
+++ b/source/rest/iapiv1.d
@@ -10,7 +10,8 @@ interface IApiV1
 	/+
 		POST /api/v1/run
 		{
-			source: "..."
+			source: "...",
+			compiler: "dmd" (available: ["dmd-nightly", "dmd-beta", "dmd", "ldc-beta", "ldc", "gdc"])
 		}
 
 		Returns: output of compiled D program with success

--- a/source/rest/iapiv1.d
+++ b/source/rest/iapiv1.d
@@ -34,7 +34,7 @@ interface IApiV1
 	}
 	@method(HTTPMethod.POST)
 	@path("/api/v1/run")
-	RunOutput run(string source);
+	RunOutput run(string source, string compiler = "dmd");
 
 	/+
 		POST /api/v1/format


### PR DESCRIPTION
With the new https://github.com/dlang-tour/core-exec Docker images, it's rather simple to allow choosing a compiler:

![image](https://user-images.githubusercontent.com/4370550/27962175-59e1d4d6-6331-11e7-9262-79d0830d777f.png)

![image](https://user-images.githubusercontent.com/4370550/27962247-94881064-6331-11e7-89cc-870fe44be72a.png)

### TODO:

- [ ] Fix `gdmd` wrapper (it requires Perl to be installed) or remove gdc support for now
- [ ] Add select box for the frontend (will be a follow-up PR)
- [ ] Add compiler to the sourceCode hashing (though this can be a follow-up PR as well)
- [ ] Get feedback from @stonemaster 

To test this locally, one needs to set docker as execution provider in the `config.yml`. As it will fetch all docker images on start, the first startup might take a bit.