### PR TITLE
Disable DMD beta until issue 17608 is fixed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ d:
   # used to build the release application
   - ldc-1.3.0-beta2
 
+# temporarily disabled due to https://issues.dlang.org/show_bug.cgi?id=17614
+matrix:
+    allow_failures:
+        - d: dmd-beta
+
 cache:
   - $HOME/.dub
 


### PR DESCRIPTION
Temporarily disable `dmd-beta`, s.t. auto-merge works again.