### PR TITLE
Re-enable dmd-beta

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,11 +14,6 @@ d:
   # used to build the release application
   - ldc-1.3.0-beta2
 
-# temporarily disabled due to https://issues.dlang.org/show_bug.cgi?id=17614
-matrix:
-    allow_failures:
-        - d: dmd-beta
-
 cache:
   - $HOME/.dub
 


### PR DESCRIPTION
- DMD 2.075.0-b4 should fix the __VERSION__ regression in Vibe.d