### PR TITLE
[hotfix] Use JS implementation to parse sourceCode

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -111,7 +111,12 @@ dlangTourApp.controller('DlangTourAppCtrl',
 	}
 
 	$scope.initEditor = function(sourceCode) {
-		$scope.resetCode = b64DecodeUnicode(sourceCode);
+
+		var source = $location.search().source;
+		if (!source) {
+			source = b64DecodeUnicode(sourceCode);
+		}
+		$scope.resetCode = source;
 		$scope.sourceCode = $scope.resetCode;
 	}
 


### PR DESCRIPTION
Currently Chrome silently replaces escaped semicolons to semicolons, e.g.

https://run.dlang.io?compiler=dmd-nightly&source=void%20main(string%5B%5D%20args)%0A%7B%0A%20%20%20%20static%20foreach%20(i%3B%20%5B0%2C1%2C2%2C3%5D)%0A%09%7B%0A%20%20%20%20%09pragma(msg%2C%20i)%3B%0A%20%20%20%20%7D%0A%7D

->

https://run.dlang.io/?compiler=dmd-nightly&source=void%20main(string%5B%5D%20args)%0A%7B%0A%20%20%20%20static%20foreach%20(i;%20%5B0,1,2,3%5D)%0A%09%7B%0A%20%20%20%20%09pragma(msg,%20i);%0A%20%20%20%20%7D%0A%7D

Vibe.d, however, correctly stops reading parameters on a semi-colon.
In the future, we might want to sue base64 (it's already supported) to completely avoid this problem, but this might result in longer or less legible URLs.