### PR TITLE
Allow building & comparing output from old D compilers for the editor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
   # Compile to static binary with ldc
   - if [[ "${DC}" == "ldc2" ]]; then  dub build -c static --compiler=${DC}; fi
   - if [[ "${DC}" == "ldc2" ]]; then docker build -t stonemaster/dlang-tour . ; fi
-  - if [[ "${DC}" == "ldc2" ]]; then docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti stonemaster/dlang-tour --sanitycheck ; fi
+  - if [[ "${DC}" == "ldc2" ]]; then docker run --rm -v /var/run/docker.sock:/var/run/docker.sock -ti stonemaster/dlang-tour --wait-until-pulled --sanitycheck ; fi
 
 after_success:
   - if [[ "${DC}" == "ldc2" && "$(ldc2 --version | head -n1 | sed -E 's/.*\((.*)\).*/\1/')" == "1.3.0-beta2" && "${TRAVIS_BRANCH}" == "master" && "${TRAVIS_PULL_REQUEST}" == "false" ]]; then docker login -e="$DOCKER_EMAIL" -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"; fi

--- a/source/app.d
+++ b/source/app.d
@@ -13,6 +13,8 @@ import exec.iexecprovider;
 import exec.off;
 import exec.docker;
 
+bool waitUntilPulled;
+
 /++ Factory method that returns an execution provider
     depending on the configuration settings.
 +/
@@ -34,7 +36,8 @@ private IExecProvider createExecProvider(Config config,
 					config.dockerExecConfig.maximumOutputSize,
 					config.dockerExecConfig.maximumQueueSize,
 					config.dockerExecConfig.memoryLimit,
-					config.dockerExecConfig.dockerBinaryPath);
+					config.dockerExecConfig.dockerBinaryPath,
+					waitUntilPulled);
 			break;
 		default:
 			throw new Exception("Unknown exec provider %s".format(config.execProvider));
@@ -104,6 +107,7 @@ shared static this()
 	string defaultLang = "en";
 
 	readOption("c|config", &configFile, "Configuration file");
+	readOption("wait-until-pulled", &waitUntilPulled, "Wait until all docker images have been pulled.");
 	readOption("sanitycheck", &sanityCheck,
 	    "Runs sanity check before starting that checks whether all source code examples actually compile; doesn't start the service");
 	readOption("lang-dir|l", &customLangDirectory, "Language directory");

--- a/source/exec/docker.d
+++ b/source/exec/docker.d
@@ -26,6 +26,7 @@ class Docker: IExecProvider
 		BaseDockerImage ~ ":ldc",
 		BaseDockerImage ~ ":ldc-beta",
 		//BaseDockerImage ~ ":gdc"
+		"dlangtour/core-dreg:latest",
 	];
 
 	private int timeLimitInSeconds_;

--- a/views/editor.dt
+++ b/views/editor.dt
@@ -28,6 +28,7 @@ block content
 						option(value="dmd-nightly") dmd-nightly
 						option(value="ldc-beta") ldc-beta
 						option(value="ldc") ldc
+						option(value="dreg") All D compilers
 				button.btn.btn-default(ng-click="format()")
 					span Format
 					i.fa.fa-magic(aria-hidden="true")


### PR DESCRIPTION
When watching [CyberShadow's Bugzilla](https://youtu.be/qpUTvMokTCs) I spotted this amazing tool [`dreg`](https://github.com/CyberShadow/misc/blob/master/dreg.d) and hey it's not that hard to [build a docker image for it](https://github.com/dlang-tour/core-dreg) and make it available for everyone, s.t. no setup is required.

N.B.: Currently the docker image doesn't build all versions (it takes too long to execute everything), but auto-deploy is already configured & we can easily add more versions.

It already works nicely on the CLI:

![image](https://user-images.githubusercontent.com/4370550/28425229-ec610f1e-6d6f-11e7-9e19-8315a18082f1.png)

As `dreg` runs multiple compilers in parallel, it requires more memory as well. For my tests increasing it from 128M to 256M seems to work well, but just to be sure I would increase it to 512M for `dreg` (the machine only allows 10 compilations in parallel anyways).

Things TODO
-----------------

- [x] Disable all coloring for the web output (not perfect yet)
- [x] Figure out how many versions can be run, s.t. the experience is "smooth"

Preview
-----------

![image](https://user-images.githubusercontent.com/4370550/28427557-e031f030-6d76-11e7-8869-588ad5a17b45.png)

![image](https://user-images.githubusercontent.com/4370550/28427579-efa47f74-6d76-11e7-9bbb-4cf4cf746371.png)


CC @CyberShadow