### PR TITLE
Soft-fail on clipboard errors

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -162,11 +162,15 @@ dlangTourApp.controller('DlangTourAppCtrl',
 
 	// boostrap copy-to-clipboard buttons (only necessary once)
 	if (typeof(window.Clipboard) !== "undefined") {
-		new window.Clipboard('.copy-btn', {
+		try {
+			new window.Clipboard('.copy-btn', {
 			text: function(trigger) {
 				return $scope.shortLinkURL;
 			}
 		});
+		} catch(e) {
+			console.log("Creating the copy button failed due to: ", e);
+		}
 	}
 	$scope.shorten = function() {
 		$http.post('/api/v1/shorten', {


### PR DESCRIPTION
The newest alpha of Chrome seems to define this as well, so let's better make it soft-fail.