### PR TITLE
Editor: show program output on the right for large devices

### DIFF
--- a/views/editor.dt
+++ b/views/editor.dt
@@ -10,7 +10,7 @@ block head
 
 block content
 	.row(ng-controller="DlangTourAppCtrl as ctrl", ng-init="initEditor('#{sourceCode}')")
-		div#tour-content(ng-show="showProgramOutput")
+		div#tour-content(ng-show="showProgramOutput", class="visible-xs-block")
 			.content-command-box
 				button.btn.btn-danger.btn-sm(ng-click="showProgramOutput = !showProgramOutput")
 					span.fa.fa-close
@@ -45,7 +45,12 @@ block content
 					input#shortlink-input(ng-value="shortLinkURL", size="16")
 					button.copy-btn(data-clipboard-target="#shortlink-input", data-clipboard-action="copy")
 						img.clipy(src="/static/img/clippy.svg", alt="Copy to clipboard", width="13")
+		div(class="col-md-7 col-sm-12': showContent", style="padding-left: 0px; padding-right: 0px")
 			ui-codemirror(ui-codemirror-opts="editorOptions", ui-codemirror="{ onLoad : codemirrorLoaded }", ng-model="sourceCode")
+		div(ng-show="showProgramOutput", class="col-md-5 hidden-xs")
+			b.program-output-title > rdmd playground.d
+			hr
+			pre#program-output {{programOutput}}
 
 block js
 	script(src="/static/js/tour-controller.js")


### PR DESCRIPTION
This seems more natural and the layout doesn't change on "Run":

![image](https://user-images.githubusercontent.com/4370550/28495190-138b10e4-6f46-11e7-825f-047d1a17cbe6.png)

Large display:

![image](https://user-images.githubusercontent.com/4370550/28495191-19694ba2-6f46-11e7-8fc8-c367a86f8ad5.png)

Mobile stays the same.