### PR TITLE
Temporarily remove Docker cleanup

### DIFF
--- a/source/exec/docker.d
+++ b/source/exec/docker.d
@@ -84,7 +84,7 @@ class Docker: IExecProvider
 						//new Exception("Compiling 'Hello World' wasn't successful: " ~ result.output));
 			}
 			// Remove previous, untagged images
-			executeShell("docker images --no-trunc | grep '<none>' | awk '{ print $3 }' | xargs -r docker rmi");
+			//executeShell("docker images --no-trunc | grep '<none>' | awk '{ print $3 }' | xargs -r docker rmi");
 			ownerTid.send(true);
 		}, this.dockerBinaryPath_, DockerImages);
 		if (waitUntilPulled)


### PR DESCRIPTION
Even though it only old docker images are removed, there seems to be a problem with docker images getting removed on a redeploy - it could also be related to the watchtower in place, but I am trying to reduce the sources of error for now.