### PR TITLE
Enable coloring support

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -124,6 +124,10 @@ dlangTourApp.controller('DlangTourAppCtrl',
 	var nanobar = new Nanobar({
 		target: document.getElementById('nanobar'),
 	});
+	
+	var ansi_up = new AnsiUp;
+	ansi_up.use_classes = true;
+
 	$scope.run = function() {
 		$scope.programOutput = $sce.trustAsHtml("... Waiting for remote service ...");
 		$scope.inProgress = true;
@@ -143,16 +147,10 @@ dlangTourApp.controller('DlangTourAppCtrl',
 		$http.post('/api/v1/run', {
 			source: $scope.sourceCode,
 			compiler: $scope.compiler,
-			args: "-color"
+			color: true
 		}).then(function(body) {
 			var data = body.data;
-			if (typeof AnsiUp !== "undefined") {
-				var ansi_up = new AnsiUp;
-				ansi_up.use_classes = true;
-				$scope.programOutput = $sce.trustAsHtml(ansi_up.ansi_to_html(data.output));
-			} else {
-				$scope.programOutput = data.output;
-			}
+			$scope.programOutput = $sce.trustAsHtml(ansi_up.ansi_to_html(data.output));
 			$scope.warnings = data.warnings;
 			$scope.errors = data.errors;
 			// Enable linting
@@ -161,7 +159,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 			});
 		}, function(error) {
 			var msg = (error || {}).statusMessage || "";
-			$scope.programOutput = "Server error: " + msg;
+			$scope.programOutput = $sce.trustAsHtml("Server error: " + msg);
 		}).finally(function(){
 			clearInterval(progressInterval);
 			$scope.inProgress = false;

--- a/source/exec/docker.d
+++ b/source/exec/docker.d
@@ -117,11 +117,17 @@ class Docker: IExecProvider
 		// use dmd as fallback
 		const dockerImage = (r.length > 0) ? r[0] : DockerImages[0];
 
+        auto env = [
+            "DOCKER_ARGS": input.args,
+            "DOCKER_COLOR": input.color ? "on" : "off",
+        ];
 		auto docker = pipeProcess([this.dockerBinaryPath_, "run", "--rm",
+		        "-e", "DOCKER_COLOR",
+		        "-e", "DOCKER_ARGS",
 				"--net=none", "--memory-swap=-1",
 				"-m", to!string(memoryLimitMB_ * 1024 * 1024),
 				dockerImage, encoded],
-				Redirect.stdout | Redirect.stderrToStdout | Redirect.stdin);
+				Redirect.stdout | Redirect.stderrToStdout | Redirect.stdin, env);
 		docker.stdin.write(encoded);
 		docker.stdin.flush();
 		docker.stdin.close();

--- a/source/exec/iexecprovider.d
+++ b/source/exec/iexecprovider.d
@@ -14,6 +14,7 @@ interface IExecProvider
 		string compiler = "dmd";
 		string args;
 		string stdin;
+		bool color;
 	}
 	Tuple!(string, "output", bool, "success") compileAndExecute(RunInput input);
 }

--- a/source/exec/stupidlocal.d
+++ b/source/exec/stupidlocal.d
@@ -81,6 +81,7 @@ class StupidLocal: IExecProvider
 			tmpfile.close();
 			auto args = [dCompiler];
 			args ~= input.args.split(" ");
+			args ~= "-color=" ~ (input.color ? "on " : "off ");
 			args ~= "-run";
 			args ~= tmpfile.name;
 
@@ -91,7 +92,7 @@ class StupidLocal: IExecProvider
 			];
 			auto fakeTty = `
 faketty () { script -qfc "$(printf "%q " "$@")" /dev/null ; }
-faketty ` ~ args.join(" ") ~  ` | cat`;
+faketty ` ~ args.join(" ") ~  ` | cat | sed 's/\r$//'`;
 
 			auto rdmd = fakeTty.executeShell(env);
 			result.success = rdmd.status == 0;

--- a/source/rest/iapiv1.d
+++ b/source/rest/iapiv1.d
@@ -40,8 +40,8 @@ interface IApiV1
 		@optional string compiler = "dmd";
 		@optional string stdin;
 		@optional string args;
+		@optional bool color;
 	}
-
 
 	@bodyParam("input")
 	@method(HTTPMethod.POST)

--- a/views/editor.dt
+++ b/views/editor.dt
@@ -52,7 +52,7 @@ block content
 		div(ng-show="showProgramOutput", class="col-md-5 hidden-xs")
 			b.program-output-title > rdmd playground.d
 			hr
-			pre#program-output {{programOutput}}
+			pre#program-output(ng-bind-html="programOutput")
 
 block js
 	script(src="/static/js/tour-controller.js")

--- a/views/tour.dt
+++ b/views/tour.dt
@@ -6,6 +6,7 @@ block head
 	link(rel="stylesheet", href="/static/lib/codemirror/addon/lint/lint.min.css")
 	link(rel="stylesheet", href="/static/lib/codemirror/theme/elegant.css")
 	link(rel="stylesheet", href="/static/lib/grid12.min.css")
+	link(rel="stylesheet", href="/static/css/ansi.css")
 
 block content
 	.row(ng-controller="DlangTourAppCtrl as ctrl", ng-init="initTour('#{language}', '#{githubRepo}', '#{chapterId}', '#{section}', #{hasSourceCode}, '#{previousSection.link}', '#{nextSection.link}')")
@@ -25,7 +26,7 @@ block content
 						span.fa.fa-close
 				h2.program-output-title rdmd playground.d
 				div#nanobar(ng-show="inProgress")
-				pre#program-output {{programOutput}}
+				pre#program-output(ng-bind-html="programOutput")
 		div(ng-class="{'col-md-5 col-sm-12': showContent, 'col-md-12': !showContent}", ng-show="showSourceCode", style="padding-left: 0px; padding-right: 0px")
 			div#command-box.text-right
 				button.btn.btn-default(ng-click="showContent = !showContent")
@@ -73,3 +74,4 @@ block js
 	script(src="/static/lib/ui-codemirror.min.js")
 	script(src="/static/lib/hotkeys.min.js")
 	script(src="/static/lib/nanobar.min.js")
+	script(src="/static/lib/ansi_up.min.js")


### PR DESCRIPTION
- Use `sed` to remove the coloring until we have found a D replacement
- Uses coloring by default for the DTour and run.dlang.io