### PR TITLE
Add a 'Add library button'

### DIFF
--- a/public/static/css/editor.css
+++ b/public/static/css/editor.css
@@ -44,3 +44,17 @@
     outline: none;
     box-shadow: inset 0 1px 2px rgba(0,0,0,0.075);
 }
+
+#add-library {
+	display: inline-block;
+}
+
+#add-library-select {
+	display: block;
+	position: absolute;
+	z-index: 2;
+	margin-top: -35px;
+	opacity: 0;
+	width: 115px;
+	height: 34px;
+}

--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -124,7 +124,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 	var nanobar = new Nanobar({
 		target: document.getElementById('nanobar'),
 	});
-	
+
 	var ansi_up = new AnsiUp;
 	ansi_up.use_classes = true;
 
@@ -228,6 +228,41 @@ dlangTourApp.controller('DlangTourAppCtrl',
 		}).success(function(data) {
 			$scope.sourceCode = data.source;
 		});
+	}
+
+	function addLibrary(name, version) {
+		// check for the header
+		if (!($scope.sourceCode.indexOf("dub.sdl:") >= 0 || $scope.sourceCode.indexOf("dub.json:") >= 0)) {
+			$scope.sourceCode = '/+dub.sdl:\nname "foo"\n+//**/\n' + $scope.sourceCode;
+		}
+		var parts = $scope.sourceCode.split("+/");
+		var after = parts.slice(1);
+		after.unshift(parts[0] + 'dependency "' + name + '" version="~>' + version + '"\n');
+		$scope.sourceCode = after.join("+/");
+	}
+
+	$scope.availableLibraries = [
+		{name: "mir", version:"1.1.1"},
+		{name: "mir-algorithm", version:"0.6.7"},
+		{name: "vibe-d", version:"0.8.0"},
+		{name: "libdparse", version:"0.7.0"}
+	];
+	$scope.showAvailableLibraries = false;
+	$scope.availableLibrary = "";
+	var addLibrarySelect = document.getElementById("add-library-select");
+
+	$scope.addLibrary = function() {
+		$scope.showAvailableLibraries = true;
+		addLibrarySelect.focus();
+		addLibrarySelect.style.opacity = 1;
+	}
+	$scope.onAddLibrary = function() {
+		var parts = $scope.availableLibrary.split(" ");
+		addLibrary(parts[0], parts[1]);
+		addLibrarySelect.style.opacity = 0;
+	}
+	$scope.onBlurLibrary = function() {
+		addLibrarySelect.style.opacity = 0;
 	}
 
 	// Add hotkeys

--- a/views/editor.dt
+++ b/views/editor.dt
@@ -31,6 +31,12 @@ block content
 						option(value="ldc-beta") ldc-beta
 						option(value="ldc") ldc
 						option(value="dreg") All D compilers
+				div#add-library
+					button.btn.btn-default(ng-click="addLibrary()")
+						span Add library
+						i.fa.fa-plus(aria-hidden="true")
+					select#add-library-select(ng-model="availableLibrary", name="availableLibrary", ng-change="onAddLibrary()", ng-blur="onBlurLibrary()")
+						option(ng-repeat="lib in availableLibraries", ng-value="lib.name + ' ' + lib.version") {{ lib.name }} {{ lib.version }}
 				button.btn.btn-default(ng-click="format()")
 					span Format
 					i.fa.fa-magic(aria-hidden="true")


### PR DESCRIPTION
Should be very convenient:

![image](https://user-images.githubusercontent.com/4370550/28499745-3417ac06-6fbd-11e7-9b4c-388237f9cf3d.png)

results in:

![image](https://user-images.githubusercontent.com/4370550/28499747-3ebfdcaa-6fbd-11e7-8a73-4c8c5140a5c4.png)

In the future we might want to look into adding the import as well, but that might be a bit trickier, but we could simply hard-code it in the libraries list.