### PR TITLE
Remove default DUB single package name

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -264,7 +264,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 	function addLibrary(name, version) {
 		// check for the header
 		if (!($scope.sourceCode.indexOf("dub.sdl:") >= 0 || $scope.sourceCode.indexOf("dub.json:") >= 0)) {
-			$scope.sourceCode = '/+dub.sdl:\nname "foo"\n+/\n' + $scope.sourceCode;
+			$scope.sourceCode = '/+dub.sdl:\n+/\n' + $scope.sourceCode;
 		}
 		var parts = $scope.sourceCode.split("+/");
 		var after = parts.slice(1);


### PR DESCRIPTION
This has been part of DUB since 1.5.0 -> time to switch 

See https://github.com/dlang/dub/pull/1081 for details.