### PR TITLE
Don't add -asm twice

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -212,9 +212,9 @@ dlangTourApp.controller('DlangTourAppCtrl',
 
 	$scope.asm = function() {
 		var args = $scope.args || "";
-		if ($scope.compiler.indexOf("dmd") >=0) {
+		if ($scope.compiler.indexOf("dmd") >=0 && args.indexOf("-asm") < 0) {
 			args += " -asm";
-		} else if ($scope.compiler.indexOf("ldc") >=0) {
+		} else if ($scope.compiler.indexOf("ldc") >=0 && args.indexOf("-output-s") < 0) {
 			args += " -output-s";
 		} else {
 			$scope.programOutput = $scope.compiler + " doesn't support ASM output";
@@ -224,7 +224,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 
 	$scope.ir = function() {
 		var args = $scope.args || "";
-		if ($scope.compiler.indexOf("ldc") >=0) {
+		if ($scope.compiler.indexOf("ldc") >=0 && args.indexOf("-output-ll") < 0) {
 			args += " -output-ll";
 		} else {
 			$scope.programOutput = $scope.compiler + " doesn't support ASM output";


### PR DESCRIPTION
Example: https://run.dlang.io/?compiler=dmd&source=import%20core.stdc.stdio;%0Avoid%20main(string%5B%5D%20args)%0A%7B%0A%20%20%20%20printf(%22Hello%20%5Cn%22);%0A%7D&args=-asm

"Run" works, "ASM" doesn't because we add `-asm` twice and the Docker wrapper isn't smart enough for this.