### PR TITLE
Remove workaround to read the json manually

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -5,18 +5,18 @@
 		"botan-math": "1.0.3",
 		"dfmt": "0.5.0",
 		"diet-ng": "1.4.3",
-		"dyaml": "0.6.3",
+		"dyaml": "0.6.4",
 		"eventcore": "0.8.27",
 		"libasync": "0.8.3",
 		"libdparse": "0.7.1",
 		"libevent": "2.0.2+2.0.16",
 		"memutils": "0.4.9",
 		"mustache-d": "0.1.3",
-		"mustache-d-dlang-tour": "0.1.2",
 		"openssl": "1.1.6+1.0.1g",
-		"taggedalgebraic": "0.10.8",
+		"stdx-allocator": "2.77.0",
+		"taggedalgebraic": "0.10.9",
 		"tinyendian": "0.1.2",
-		"vibe-core": "1.3.0",
+		"vibe-core": "1.4.0-alpha.1",
 		"vibe-d": "0.8.2"
 	}
 }

--- a/source/app.d
+++ b/source/app.d
@@ -186,11 +186,7 @@ shared static this()
 		// parse json sent via text/plain to avoid an additional preflight OPTIONS request
 		// https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS#Preflighted_requests
 		if (req.contentType == "text/plain")
-		{
 			req.contentType = "application/json; charset=UTF-8";
-			auto bodyStr = req.bodyReader.readAllUTF8;
-			if (!bodyStr.empty) req.json = parseJson(bodyStr);
-		}
 	}
 
 	urlRouter


### PR DESCRIPTION
This was making the application crash with a rather hard to detect error message from `Nullable.get` and `Vibe.d`. I should probably look into issuing a better error message at Vibe.d