### PR TITLE
Improve the HTML IFrame CSS to wrap long content

### DIFF
--- a/public/static/css/editor.css
+++ b/public/static/css/editor.css
@@ -74,12 +74,12 @@ iframe {
     display: block;
     border: none;         /* Reset default border */
     width: 100%;
-	min-height: 100%;
-	position: fixed;
+    height: calc(100vh - 165px);
+	position: relative;
 }
 
 @media only screen and (max-width: 767px) {
 	iframe {
-		position: relative;
+		height: 30vh;
 	}
 }


### PR DESCRIPTION
This is a bit problematic because the naive:

```css
width: 100%;
height: 100%;
```

doesn't wort as the parent container only has a height of ~300px. The previous
trick with `position: fixed` has its downsides too, so I went with calculating
the `width` manually based on the maximal height of the buttons above. It's not
the best solution, but should look nice in 98% of all cases and this only changes
the formatting for the HTML preview anyways.