### PR TITLE
Add specific run.dlang.io help page

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -154,7 +154,8 @@ shared static this()
 		auto chapterId = "";
 		auto language = "en";
 		const name = "DLang Tour";
-		res.render!("error.dt", req, error, language, googleAnalyticsId, chapterId, toc, title, name)();
+		const topHelpLink = "https://github.com/dlang-tour/core/issues/new";
+		res.render!("error.dt", req, error, language, googleAnalyticsId, chapterId, toc, title, name, topHelpLink)();
 		res.finalize();
 	};
 

--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -165,10 +165,11 @@ class WebInterface
 		auto githubRepo = meta.repo;
 		auto translations = meta.translator;
 		const name = "DLang Tour";
+		const topHelpLink = "https://github.com/dlang-tour/core/issues/new";
 		render!("tour.dt", htmlContent, language, section, sectionId,
 				sectionCount, chapterId, hasSourceCode, sourceCodeEnabled,
 				nextSection, previousSection, googleAnalyticsId,
-				toc, title, githubRepo, translations, name)();
+				toc, title, githubRepo, translations, name, topHelpLink)();
 	}
 
 	private static auto buildDlangToc()
@@ -287,7 +288,8 @@ class WebInterface
 		const language = "en";
 		const name = "run.dlang.io";
 		static immutable toc = buildDlangToc();
-		render!("editor.dt", googleAnalyticsId, title, toc, chapterId, language, sourceCode, name)();
+		string topHelpLink = "https://github.com/dlang-tour/core/wiki/run.dlang.io";
+		render!("editor.dt", googleAnalyticsId, title, toc, chapterId, language, sourceCode, name, topHelpLink)();
 	}
 
 	@path("/is/:id")

--- a/views/base.dt
+++ b/views/base.dt
@@ -55,7 +55,7 @@ body(ng-app="DlangTourApp", class="ng-cloak")
 					#github_avatar
 						a(href="https://github.com/dlang-tour/core")
 							i(class="fa fa-github",aria-hidden="true")
-						a(href="https://github.com/dlang-tour/core/issues/new")
+						a(ng-href=(topHelpLink))
 							i(class="fa fa-question-circle",aria-hidden="true")
 
 	block content


### PR DESCRIPTION
Makes the help icon on the top right dependent on the context and links to the new wiki page for run.dlang.io: https://github.com/dlang-tour/core/wiki/run.dlang.io