### PR TITLE
Update the list of installed DUB packages automatically by checking the list of installed DUB packages from the Docker container

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -393,13 +393,6 @@ dlangTourApp.controller('DlangTourAppCtrl',
 		$scope.sourceCode = after.join("+/");
 	}
 
-	$scope.availableLibraries = [
-		{name: "mir", version:"1.1.1"},
-		{name: "mir-algorithm", version:"0.6.14"},
-		{name: "vibe-d", version:"0.8.2"},
-		{name: "libdparse", version:"0.7.2"},
-		{name: "emsi_containers", version:"0.6.0"},
-	];
 	$scope.showAvailableLibraries = false;
 	$scope.availableLibrary = "none";
 	var addLibrarySelect = document.getElementById("add-library-select");

--- a/source/app.d
+++ b/source/app.d
@@ -190,9 +190,12 @@ shared static this()
 			req.contentType = "application/json; charset=UTF-8";
 	}
 
+	// refresh the list of DUB packages installed once on the start
+	auto installedPackages = execProvider.installedPackages();
+	logInfo("Installed DUB Packages: %s", installedPackages);
 	urlRouter
 		.any("/api/*", &cors)
-		.registerWebInterface(new WebInterface(contentProvider, config.googleAnalyticsId, defaultLang))
+		.registerWebInterface(new WebInterface(contentProvider, config.googleAnalyticsId, defaultLang, installedPackages))
 		.registerRestInterface(new ApiV1(execProvider, contentProvider))
 		.get("/static/*", serveStaticFiles(publicDir.buildPath("static"), fsettings));
 

--- a/source/exec/cache.d
+++ b/source/exec/cache.d
@@ -55,6 +55,11 @@ class Cache: IExecProvider
 			return result;
 		}
 	}
+
+	Package[] installedPackages()
+	{
+		return realExecProvider_.installedPackages;
+	}
 }
 
 private uint getSourceCodeHash(string source)

--- a/source/exec/docker.d
+++ b/source/exec/docker.d
@@ -186,4 +186,23 @@ class Docker: IExecProvider
 
 		return typeof(return)(output, success);
 	}
+
+	Package[] installedPackages()
+	{
+		import std.array : array;
+		import std.algorithm.iteration : filter, joiner, map, splitter;
+		import std.range : empty, dropOne;
+		import std.functional;
+
+		auto res = execute([dockerBinaryPath_, "run", "--rm", "--entrypoint=/bin/cat", DockerImages[0], "/installed_packages"]);
+		enforce(res.status == 0, "Error:" ~ res.output);
+		return res.output
+			.splitter("\n")
+			.filter!(not!empty)
+			.map!((l){
+				auto ps = l.splitter(":");
+				return Package(ps.front, ps.dropOne.front.filter!(a => a != '"').to!string);
+			})
+			.array;
+	}
 }

--- a/source/exec/iexecprovider.d
+++ b/source/exec/iexecprovider.d
@@ -2,6 +2,8 @@ module exec.iexecprovider;
 
 import std.typecons: Tuple;
 
+alias Package = Tuple!(string, "name", string, "version_");
+
 /++
 	Interface for exec providers that take source code
 	and output the compiled program's output.
@@ -17,4 +19,8 @@ interface IExecProvider
 		bool color;
 	}
 	Tuple!(string, "output", bool, "success") compileAndExecute(RunInput input);
+
+
+	// returns a list of all installed DUB packages
+	Package[] installedPackages();
 }

--- a/source/exec/off.d
+++ b/source/exec/off.d
@@ -10,4 +10,9 @@ class Off: IExecProvider
 	{
 		return typeof(return)("Service currently unavailable", false);
 	}
+
+	Package[] installedPackages()
+	{
+		return null;
+	}
 }

--- a/source/exec/stupidlocal.d
+++ b/source/exec/stupidlocal.d
@@ -115,4 +115,9 @@ faketty ` ~ 	args.join(" ") ~  ` | cat | sed 's/\r$//'`;
 
 		return result;
 	}
+
+	Package[] installedPackages()
+	{
+		return null;
+	}
 }

--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -6,6 +6,7 @@ import std.traits: ReturnType;
 import std.typecons: Tuple;
 
 import contentprovider;
+import exec.iexecprovider;
 
 /++
 	Main entry point for user visible content
@@ -23,14 +24,17 @@ class WebInterface
 			///< language, chapter and section indexing
 		string googleAnalyticsId_; ///< ID for google analytics
 		string defaultLang = "en";
+
+		Package[] installedPackages_;
 	}
 
 	this(ContentProvider contentProvider,
-		string googleAnalyticsId, string defaultLang)
+		string googleAnalyticsId, string defaultLang, Package[] installedPackages)
 	{
 		this.contentProvider_ = contentProvider;
 		this.googleAnalyticsId_ = googleAnalyticsId;
 		this.defaultLang = defaultLang;
+		this.installedPackages_ = installedPackages;
 
 		// Fetch all table-of-contents for all supported
 		// languages (just 'en' for now) and generate
@@ -289,7 +293,8 @@ class WebInterface
 		const name = "run.dlang.io";
 		static immutable toc = buildDlangToc();
 		string topHelpLink = "https://github.com/dlang-tour/core/wiki/run.dlang.io";
-		render!("editor.dt", googleAnalyticsId, title, toc, chapterId, language, sourceCode, name, topHelpLink)();
+		auto installedPackages = installedPackages_;
+		render!("editor.dt", googleAnalyticsId, title, toc, chapterId, language, sourceCode, name, topHelpLink, installedPackages)();
 	}
 
 	@path("/is/:id")

--- a/views/editor.dt
+++ b/views/editor.dt
@@ -42,7 +42,8 @@ block content
 							i.fa.fa-plus(aria-hidden="true")
 						select#add-library-select(ng-model="availableLibrary", name="availableLibrary", ng-change="onAddLibrary()", ng-blur="onBlurLibrary()")
 							option(value="none") None
-							option(ng-repeat="lib in availableLibraries", ng-value="lib.name + ' ' + lib.version") {{ lib.name }} {{ lib.version }}
+							- foreach (p; installedPackages)
+								option(value="#{p.name} #{p.version_}") #{p.name } #{p.version_}
 
 					span.hidden-xs.hidden-sm.hidden-md
 						button.btn.btn-default(ng-click="ir()",ng-show="compiler.indexOf('ldc') >= 0")


### PR DESCRIPTION
This should avoid the need of any manual updates in the future. If specific bumps or locks are required, this can be done entirely in the core-exec package. It's the single source of truth now.

It's all based on this simple idea to use an alternative entrypoint:

```sh
docker run --rm --entrypoint=/bin/cat dlangtour/core-exec:dmd /installed_packages
```