### PR TITLE
Use Travis addons to install packages + add libblas and liblapack

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,12 @@ branches:
     - master
     - testing
 
-before_install:
-  - sudo apt-get -qq update
-  - sudo apt-get install -y libevent-dev
+addons:
+  apt:
+    packages:
+    - libevent-dev
+    - libblas-dev
+    - liblapack-dev
 
 script:
   # Update all language repos to their latest content


### PR DESCRIPTION
liblas and liblapack are required due to https://github.com/dlang-tour/english/pull/237.
Not sure whether it's the best idea to test the dub series in this way, but for now it only adds two dependencies, so it shouldn't hurt to much.