### PR TITLE
Disable failing LDC build for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ d:
   - dmd
   - dmd-beta
   - dmd-nightly
-  - ldc
+  #- ldc
 
 matrix:
   include:


### PR DESCRIPTION
LDC 1.8.0 has a DUB regression (?) which leads to a build error with the EMSI containers snippet.
For now, this disables LDC 1.8.0 as 1.7 is still tested.