### PR TITLE
Use GH-API for authenticated Gist Exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,13 @@ To enable **Google Analytics** please specify the environment variable
 `GOOGLE_ANALYTICS_ID` and set it to the tracking ID provided
 for your Analytics account.
 
+#### `GITHUB_TOKEN`
+
+> default: (empty)
+
+Required for exporting Gists to GitHub.
+Follow [these instrutions](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line) to generate a CLI GitHub token.
+
 #### `EXEC_DOCKER_MEMORY_LIMIT`
 
 > default: 256

--- a/config.yml
+++ b/config.yml
@@ -3,6 +3,7 @@ public_dir: "public"
 listen:
     - 127.0.0.1
 google_analytics_id: ""
+github_token: ""
 tls:
     caChainFile: "server.crt"
     privateKeyFile: "server.pem"

--- a/docker/config.docker.yml
+++ b/docker/config.docker.yml
@@ -3,6 +3,7 @@ public_dir: "public"
 listen:
     - 0.0.0.0
 google_analytics_id: "%GOOGLE_ANALYTICS_ID%"
+github_token: "%GITHUB_TOKEN%"
 tls:
     caChainFile: "%TLS_CA_CHAIN_FILE%"
     privateKeyFile: "%TLS_PRIVATE_KEY_FILE%"

--- a/docker/docker.start.sh
+++ b/docker/docker.start.sh
@@ -3,6 +3,7 @@ set -e -u
 
 cat /config.yml.tmpl | \
   sed "s/%GOOGLE_ANALYTICS_ID%/${GOOGLE_ANALYTICS_ID:-}/g" | \
+  sed "s/%GITHUB_TOKEN%/${GITHUB_TOKEN:-}/g" | \
   sed "s/%EXEC_DOCKER_MEMORY_LIMIT%/${EXEC_DOCKER_MEMORY_LIMIT:-512}/g" | \
   sed "s/%EXEC_DOCKER_MAX_QUEUE_SIZE%/${EXEC_DOCKER_MAX_QUEUE_SIZE:-10}/g" | \
   sed "s/%EXEC_DOCKER_TIME_LIMIT%/${EXEC_DOCKER_TIME_LIMIT:-25}/g" | \

--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -365,25 +365,24 @@ dlangTourApp.controller('DlangTourAppCtrl',
 	}
 
 	function gistURLToId(url) {
-		return url.replace("https://gist.github.com/", "").replace("anonymous/", "");
+		return url.replace("https://gist.github.com/", "")
+			      .replace("anonymous/", "")
+				  .replace("d-run/", "")
 	}
 
 	$scope.gist = function() {
 		return shortenToGist().then(function(data){
-			window.open(data.html_url, "_blank");
+			window.open(data.htmlUrl, "_blank");
 		});
 	}
 	function shortenToGist() {
-		$http.post('https://api.github.com/gists', {
-			public: true,
-			files: {
-				"main.d": {
-					content: $scope.sourceCode
-				}
-			}
+		return $http.post('/api/v1/gist', {
+			source: $scope.sourceCode,
+			compiler: $scope.compiler,
+			args: $scope.args,
 		}).then(function(body) {
 			var data = body.data;
-			$scope.shortLinkURL = window.location.origin + "/gist/" + gistURLToId(data.html_url) + editorParams();
+			$scope.shortLinkURL = window.location.origin + data.url;
 			return data;
 		}, function(error) {
 			var msg = (error || {}).statusMessage || "";

--- a/source/app.d
+++ b/source/app.d
@@ -142,6 +142,7 @@ shared static this()
 
 	logInfo("Starting Dlang-tour on %s, port %d", config.bindAddresses, config.port);
 	logInfo("Google Analytics ID: %s", config.googleAnalyticsId);
+	logInfo("GitHub Token: %s", config.githubToken);
 
 	auto settings = new HTTPServerSettings;
 	settings.port = config.port;
@@ -196,7 +197,7 @@ shared static this()
 	urlRouter
 		.any("/api/*", &cors)
 		.registerWebInterface(new WebInterface(contentProvider, config.googleAnalyticsId, defaultLang, installedPackages))
-		.registerRestInterface(new ApiV1(execProvider, contentProvider))
+		.registerRestInterface(new ApiV1(execProvider, contentProvider, config.githubToken))
 		.get("/static/*", serveStaticFiles(publicDir.buildPath("static"), fsettings));
 
 	if (startHTTPS) {

--- a/source/config.d
+++ b/source/config.d
@@ -11,6 +11,7 @@ class Config
 	private bool enableExecCache_;
 	private string publicDir_;
 	private string googleAnalyticsId_;
+	private string githubToken_;
 	private string tlsCaChainFile_;
 	private string tlsPrivateKeyFile_;
 	private ushort tlsPort_;
@@ -49,10 +50,11 @@ class Config
 	@property bool enableExecCache() { return enableExecCache_; }
 	@property string publicDir() { return publicDir_; }
 	@property string googleAnalyticsId() { return googleAnalyticsId_; }
+	@property string githubToken() { return githubToken_; }
 	@property string tlsCaChainFile() { return tlsCaChainFile_; }
 	@property string tlsPrivateKeyFile() { return tlsPrivateKeyFile_; }
 	@property ushort tlsPort() { return tlsPort_; }
-	
+
 	this(string configFile)
 	{
 		auto root = Loader(configFile).load();
@@ -63,6 +65,7 @@ class Config
 		enableExecCache_ = root["exec"]["cache"].as!bool();
 		publicDir_ = root["public_dir"].as!string();
 		googleAnalyticsId_ = root["google_analytics_id"].as!string();
+		githubToken_ = root["github_token"].as!string();
 		if ("tls" in root) {
 			tlsCaChainFile_ = root["tls"]["caChainFile"].as!string;
 			tlsPrivateKeyFile_ = root["tls"]["privateKeyFile"].as!string;

--- a/source/rest/iapiv1.d
+++ b/source/rest/iapiv1.d
@@ -95,6 +95,33 @@ interface IApiV1
 	ShortenOutput shorten(string source, string compiler, string args);
 
 	/+
+		POST /api/v1/gi
+		{
+			source: "...",
+			compiler: "dmd" (available: ["dmd-nightly", "dmd-beta", "dmd", "ldc-beta", "ldc", "gdc"]),
+			args: ""
+		}
+
+		Returns: short url to given D source
+		with success flag
+		{
+			id: "abcdef",
+			url: "/gist/abcdef",
+			htmlUrl: "http://gist.github.com/abcdef",
+		}
+	+/
+
+	struct GistOutput
+	{
+		string id;
+		string url;
+		string htmlUrl;
+	}
+	@method(HTTPMethod.POST)
+	@path("/api/v1/gist")
+	GistOutput gist(string source, string compiler, string args);
+
+	/+
 		GET /api/v1/source/CHAPTER/SECTION
 
 		Returns: source code (or empty if none) for the given


### PR DESCRIPTION
GH recently disallowed the creation of anonymous gists and now requires authentication.
This moves the authentication to the backend (with a new `GH_TOKEN` setting.)