### PR TITLE
Use the full URL for the individual snippet cache keys

### DIFF
--- a/public/static/js/tour-controller.js
+++ b/public/static/js/tour-controller.js
@@ -154,7 +154,7 @@ dlangTourApp.controller('DlangTourAppCtrl',
 		var source = loc.source;
 		if (!source) {
 			source = b64DecodeUnicode(sourceCode);
-			$scope.sourceCodeKey = window.location.hostname;
+			$scope.sourceCodeKey = window.location.href;
 		} else {
 			$scope.sourceCodeKey = "run_import_" + hashCode(source);
 		}


### PR DESCRIPTION
Improves the caching, s.t. modifications to `/gist/abcdef` are stored locally individually for this URL;