### PR TITLE
Upgrade stdx.allocator to 2.77.2

### DIFF
--- a/dub.selections.json
+++ b/dub.selections.json
@@ -13,7 +13,7 @@
 		"memutils": "0.4.9",
 		"mustache-d": "0.1.3",
 		"openssl": "1.1.6+1.0.1g",
-		"stdx-allocator": "2.77.0",
+		"stdx-allocator": "2.77.2",
 		"taggedalgebraic": "0.10.9",
 		"tinyendian": "0.1.2",
 		"vibe-core": "1.4.0-alpha.1",


### PR DESCRIPTION
This is to ensure the Jenkins CI passes at dlang/phobos#6515