### PR TITLE
Use 'import std' as default

### DIFF
--- a/source/webinterface.d
+++ b/source/webinterface.d
@@ -267,7 +267,7 @@ class WebInterface
 		} else if (auto s = "b64source" in req.query) {
 			sourceCode = *s;
 		} else {
-			auto sourceCodeRaw = "import std.stdio;\nvoid main()\n{\n    writeln(\"Hello D\");\n}";
+			auto sourceCodeRaw = "import std;\nvoid main()\n{\n    writeln(\"Hello D\");\n}";
 			sourceCode = Base64.encode(cast(ubyte[]) sourceCodeRaw);
 		}
 		auto googleAnalyticsId = googleAnalyticsId_;


### PR DESCRIPTION
Now that 2.086 is released we can just have `import std` by default.