### PR TITLE
Fix path issues when using dub

### DIFF
--- a/source/app.d
+++ b/source/app.d
@@ -78,20 +78,20 @@ private void doSanityCheck(ContentProvider contentProvider, IExecProvider execPr
 	auto content = contentProvider.getContent();
 	foreach (section; parallel(content)) {
 		if (section.sourceCode.empty) {
-			logInfo("[%s] Sanity check: Ignoring source code for section '%s' because it is empty.",
-					section.language, section.title);
+			logInfo("[%s] Sanity check: Ignoring source code for section '%s' in %s because it is empty.",
+					section.language, section.title, section.filename);
 			continue;
 		}
 
 		if (!section.sourceCodeEnabled) {
-			logInfo("[%s] Sanity check: Ignoring source code for section '%s' because it is disabled.",
-					section.language, section.title);
+			logInfo("[%s] Sanity check: Ignoring source code for section '%s' in %s because it is disabled.",
+					section.language, section.title, section.filename);
 			continue;
 		}
 
 		if (section.sourceCodeIncomplete) {
-			logInfo("[%s] Sanity check: Ignoring source code for section '%s' because it is incomplete.",
-					section.language, section.title);
+			logInfo("[%s] Sanity check: Ignoring source code for section '%s' in %s because it is incomplete.",
+					section.language, section.title, section.filename);
 			continue;
 		}
 
@@ -103,8 +103,8 @@ private void doSanityCheck(ContentProvider contentProvider, IExecProvider execPr
 		};
 		auto result = execProvider.compileAndExecute(input);
 		enforce(result.success,
-			"[%s] Sanity check: Source code for section '%s' doesn't compile:\n%s"
-			.format(section.language, section.title, result.output));
+			"[%s] Sanity check: Source code for section '%s' in %s doesn't compile:\n%s"
+			.format(section.language, section.title, section.filename, result.output));
 	}
 }
 

--- a/source/contentprovider.d
+++ b/source/contentprovider.d
@@ -37,6 +37,7 @@ class ContentProvider
 		string contentDirectory;
 
 		struct Content {
+			string filename;
 			string sourceCode;
 			bool sourceCodeEnabled = true;
 			bool sourceCodeIncomplete = false;
@@ -217,6 +218,7 @@ class ContentProvider
 							.format(filename, SourceCodeSectionTitle)));
 				enforce(content.sourceCode.empty, new Exception("%s: Double %s section in '%s'"
 							.format(filename, SourceCodeSectionTitle, content.title)));
+				content.filename = filename;
 				content.sourceCode = section.bodyOnly;
 				// ignore markdown code blocks
 				if (content.sourceCode[0..3] == "```")

--- a/source/exec/cache.d
+++ b/source/exec/cache.d
@@ -52,7 +52,7 @@ class Cache: IExecProvider
 			//auto result = realExecProvider_.compileAndExecute(input);
 			//return result;
 		if (auto cache = hash in sourceHashToOutput_) {
-			logInfo("Fetching %s from cache", input.source[0 .. min($, 20)]);
+			logInfo("Fetching '%s...' from cache", input.source[0 .. min($, 20)]);
 			return *cache;
 		} else {
 			auto result = realExecProvider_.compileAndExecute(input);

--- a/source/exec/stupidlocal.d
+++ b/source/exec/stupidlocal.d
@@ -11,7 +11,7 @@ import std.typecons: Tuple;
 import std.file: exists, remove, tempDir;
 import std.stdio: File;
 import std.random: uniform;
-import std.string: format;
+import std.string: stripRight, format;
 
 // searches the local system for valid D compilers
 private string findDCompiler()
@@ -47,7 +47,7 @@ class StupidLocal: IExecProvider
 
 	private File getTempFile()
 	{
-		auto tempdir = tempDir();
+		auto tempdir = tempDir().stripRight("/");  // dub has issues with // in path
 
 		static string randomName()
 		{


### PR DESCRIPTION
For some reason `dub` fails when there are multiple forward slashes in a path:

```
dub -q --compiler=dmd --single /var/folders/9k/jxw1lpwn6493sf_8f58p3bk80000gn/T//temp_dlang_tour_veqcpivikb.d                           

Error: module `temp_dlang_tour_veqcpivikb` from file /var/folders/9k/jxw1lpwn6493sf_8f58p3bk80000gn/T/test.d conflicts with another module temp_dlang_tour_veqcpivikb from file /var/folders/9k/jxw1lpwn6493sf_8f58p3bk80000gn/T//test.d
dmd failed with exit code 1.
```

It doesn't have anything to do with module declarations.