### PR TITLE
Adapt StupidLocal to DRuntimes new unittest default

### DIFF
--- a/source/exec/stupidlocal.d
+++ b/source/exec/stupidlocal.d
@@ -114,6 +114,7 @@ class StupidLocal: IExecProvider
 				args ~= "-color=" ~ (input.color ? "on " : "off ");
 				args ~= "-run";
 				args ~= tmpfile.name;
+				args ~= "--DRT-testmode=run-main";
 
 				// DMD requires a TTY for colored output
 				auto env = [


### PR DESCRIPTION
Executables build with unittests won't run main anymore even if all tests were
successful. Adding the Druntime flag reverts to the old behaviour.

Hopefully this makes the public examples runnable again (as Dlang-Tour uses this `IExecProvider` according to `config.yml`)