### PR TITLE
docker: use LABEL instead of deprecated MAINTAINER instruction

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM busybox:glibc
 
-MAINTAINER "André Stein <andre.stein.1985@gmail.com>"
+LABEL maintainer="André Stein <andre.stein.1985@gmail.com>"
 
 EXPOSE 8080
 


### PR DESCRIPTION
Signed-off-by: Luís Ferreira <contact@lsferreira.net>